### PR TITLE
Fix runOnInit not running 

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,7 +2,7 @@
  * moleculer-cron
  */
 
- "use strict";
+"use strict";
 
 const cron = require("cron");
 
@@ -89,10 +89,12 @@ module.exports = {
 								getJob: this.getJob,
 							}
 						), // context
-						job.runOnInit || (_ => {}), // runOnInit
+						false, // runOnInit
 						job.utcOffset || null, // utcOffset
 						job.unrefTimeout || null, // unrefTimeout
 					)
+					// Will be triggered at the start if it's defined
+					cronjob.runOnStarted = job.runOnInit;
 					cronjob.manualStart = job.manualStart || false
 					cronjob.name = job.name || this.makeid(20);
 					return cronjob;
@@ -113,6 +115,10 @@ module.exports = {
 					jobCron.start();
 				}
 				this.logger.info(`Start Cron - '${jobCron.name}'`);
+
+				if (jobCron.runOnStarted) {
+					jobCron.runOnStarted();
+				}
 				return jobCron;
 			});
 		}

--- a/test/unit/index.spec.js
+++ b/test/unit/index.spec.js
@@ -40,15 +40,17 @@ describe("Test Cron created handler", () => {
 			]
 		}
 	);
+	const instanceJob = service.$crons[0]();
 
 	it("should be created $crons", () => {
+
 		expect(service).toBeDefined();
 		expect(service.$crons).toBeDefined();
 		expect(service.$crons.length).toBe(1);
-		expect(service.$crons[0]).toBe(cronJob);
-		expect(service.$crons[0].name).toBe(nameJob);
-		expect(service.$crons[0].runOnStarted).toBeDefined();
-		expect(service.$crons[0].manualStart).toBe(false);
+		expect(instanceJob).toBe(cronJob);
+		expect(instanceJob.name).toBe(nameJob);
+		expect(instanceJob.runOnStarted).toBeDefined();
+		expect(instanceJob.manualStart).toBe(false);
 
 		expect(cron.CronJob).toHaveBeenCalledTimes(1);
 	});


### PR DESCRIPTION
`runOnInit` is ignored and and `onTick` is running instead at the start of the job. This is because `runOnInit` is of type `boolean` (and not a function) and used to control running `onTick` at the start in the `CronJob` constructor of `node-cron` package ([docs](https://github.com/kelektiv/node-cron?tab=readme-ov-file#cronjob-class)). 